### PR TITLE
Fix return type hint in get_cwes()

### DIFF
--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -166,7 +166,7 @@ class CWEFromSummaryParser(BaseParser):
     def __init__(self):
         super().__init__(PROMPT_CWE_FROM_SUMMARY, CWEList)
 
-    def get_cwes(self, summary: str) -> List[CWEList]:
+    def get_cwes(self, summary: str) -> List[str]:
         result = self.run_agent(f"**Vulnerability Description:**\n{summary}")
         return [cwe.string for cwe in result.output.cwes]
 


### PR DESCRIPTION
Addresses #17

`get_cwes()` returns `[cwe.string for cwe in result.output.cwes]`, which produces `List[str]`. The type annotation incorrectly declares the return as `List[CWEList]`. This updates it to `List[str]` to match the actual return type.

Signed-off-by: Mrityunjay Raj <mr.raj.earth@gmail.com>